### PR TITLE
bump ruby to 2.7 and update README

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "2.6.3"
+ruby "2.7.6"
 
 gem "rails", "~> 5.2.4.1"       # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem "pg"                   		  # Use Postgres as the database for Active Record

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -358,7 +358,7 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 RUBY VERSION
-   ruby 2.6.3p62
+   ruby 2.7.6p219
 
 BUNDLED WITH
    2.2.28

--- a/README.md
+++ b/README.md
@@ -22,15 +22,17 @@ more effort than just `rails s`.
     pg_ctl -D /usr/local/var/postgres -l /usr/local/var/postgres/server.log start
     ```
     (This gets old. Personally, I made a `pg_start` alias for this command)
+	You may need to replace `/usr/local/var/postgres` with your postgres database location.
     Don't forget to setup the database by running:
     ```
+    cd ~/path/to/your/app/
+	bundle install
     rake db:setup
     ```
 
 2. Next, run the rails app the way you would any other
 
     ```
-    cd ~/path/to/your/app/
     rails s
     ```
 


### PR DESCRIPTION
It seems Ruby 2.6.3 can no longer be built or installed. I got this client RI working on Ruby 2.6.10 but that reached end-of-life last month, so I'm updating the dependency spec to Ruby 2.7.6 which has support and latest security updates. Also noted bundle install to download Ruby dependencies in README file.

Other than this caveat I was able to get the client RI up and running locally.